### PR TITLE
Correct DB path for push to use local export path

### DIFF
--- a/lib/mongo_sync.rb
+++ b/lib/mongo_sync.rb
@@ -40,7 +40,7 @@ module MongoSync
                         -d #{configs['remote']['db']} \
                         -u #{configs['remote']['access']['username']} \
                         -p #{configs['remote']['access']['password']} \
-                        #{tmpdir}/#{configs['remote']['db']} \
+                        #{tmpdir}/#{configs['local']['db']} \
                         --drop > /dev/null"
 
         clean_up(tmpdir)


### PR DESCRIPTION
Hi,

i found a little bug in the sync-lib.

When running a push and the DB-names of local and remote are different it uses the wrong path.
The local export is named after the local DB, so it needs to be the local name.

For pull it's the other way around - and was correct already.

Cheers,
Benjamin
